### PR TITLE
Fix(UpStreamCARequestEntity): Overly permissive regular expression range 

### DIFF
--- a/src/main/java/net/ripe/rpki/domain/rta/UpStreamCARequestEntity.java
+++ b/src/main/java/net/ripe/rpki/domain/rta/UpStreamCARequestEntity.java
@@ -64,7 +64,7 @@ public class UpStreamCARequestEntity {
      */
     private String migrateUpstreamCARequest(String request) {
         return request.replaceAll(
-            "<(/?)net\\.ripe\\.rpki\\.offline\\.requests\\.([A-z0-9]+)>",
+            "<(/?)net\\.ripe\\.rpki\\.offline\\.requests\\.([A-Za-z0-9]+)>",
             "<$1net.ripe.rpki.commons.ta.domain.request.$2>"
         );
     }


### PR DESCRIPTION
https://github.com/RIPE-NCC/rpki-core/blob/2f1fd3633fc5167a0036e55f60e3974436e2b101/src/main/java/net/ripe/rpki/domain/rta/UpStreamCARequestEntity.java#L67-L67

Fix the issue, the overly permissive range `[A-z]` should be replaced with a more precise range that matches only the intended characters. In this case, the range `[A-Za-z]` should be used to match uppercase and lowercase letters explicitly. This change ensures that the regular expression does not unintentionally match additional characters like `[` or `\`.

The fix involves updating the regular expression in the `migrateUpstreamCARequest` method on line 67. No additional imports or dependencies are required.

---

#### References
[CVE-2021-42740: Improper Neutralization of Special Elements used in a Command in Shell-quote](https://github.com/advisories/GHSA-g4rg-993r-mgx7)
[Exploiting CVE-2021-42740](https://wh0.github.io/2021/10/28/shell-quote-rce-exploiting.html)
[no-obscure-range](https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-obscure-range.html)
[The regex [,-.]](https://pboyd.io/posts/comma-dash-dot/)
[CWE-20](https://cwe.mitre.org/data/definitions/20.html)
